### PR TITLE
Fix mac keyboard shortcuts

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -58,10 +58,9 @@
     isPhone = false,
   }: Props = $props();
 
-  // Detect if user is on Mac or Windows/Linux for keyboard shortcuts
-  const isMac =
-    typeof navigator !== "undefined" && navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-  const cmdKey = isMac ? "⌘" : "Ctrl";
+  import { isMac, controlKeyName } from "$lib/utils.js";
+
+  const cmdKey = controlKeyName;
   let logoutLoading = $state(false);
 
   async function onLogout() {

--- a/src/lib/components/utils/KeyboardShortcuts.svelte
+++ b/src/lib/components/utils/KeyboardShortcuts.svelte
@@ -13,11 +13,16 @@
 
   let { combos }: Props = $props();
 
+  const isMac =
+    typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
+
   function handleKeyDown(event: KeyboardEvent) {
+    const ctrlPressed = isMac ? event.metaKey : event.ctrlKey;
+
     const combo = combos.find((combo) => {
       return (
         combo.key.toLowerCase() === event.key.toLowerCase() &&
-        (combo.isControl ?? false) === event.ctrlKey &&
+        (combo.isControl ?? false) === ctrlPressed &&
         (combo.isShift ?? false) === event.shiftKey &&
         (combo.isAlt ?? false) === event.altKey &&
         (combo.validate?.(event) ?? true) &&

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,3 +11,8 @@ export type WithoutChild<T> = T extends { child?: any } ? Omit<T, "child"> : T;
 export type WithoutChildren<T> = T extends { children?: any } ? Omit<T, "children"> : T;
 export type WithoutChildrenOrChild<T> = WithoutChildren<WithoutChild<T>>;
 export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & { ref?: U | null };
+
+export const isMac =
+  typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
+
+export const controlKeyName = isMac ? "⌘" : "Ctrl";


### PR DESCRIPTION
## Summary
- centralize isMac detection and shortcut key name
- detect Cmd on Mac for keyboard shortcuts
- reuse helper for sidebar display

## Testing
- `pnpm lint` *(fails: 19 errors)*
- `pnpm typecheck` *(fails: svelte-check found 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853f6b41674832fbc259532b0446e66