### PR TITLE
Wait for local chat sync before navigating

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "zod": "^3.25.56"
   },
   "dependencies": {
+    "@electric-sql/experimental": "^1.0.4",
     "@electric-sql/pglite": "^0.3.3",
     "@electric-sql/pglite-sync": "^0.3.6",
     "@humanspeak/svelte-markdown": "^0.8.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@electric-sql/experimental':
+        specifier: ^1.0.4
+        version: 1.0.4(@electric-sql/client@1.0.0)
       '@electric-sql/pglite':
         specifier: ^0.3.3
         version: 0.3.3
@@ -354,6 +357,11 @@ packages:
     resolution: {integrity: sha512-wOKZyph3cvJ4J5fDwqDpR7nilPOHEFwAtbAM5X/PhV3JZCSzmkbosaQRWsxbHQ80MJv7gNFP960+TyqGAjqouQ==}
     peerDependencies:
       '@electric-sql/client': 1.0.0
+
+  '@electric-sql/experimental@1.0.4':
+    resolution: {integrity: sha512-BznyyRv0iUD8Dgg3dNrlQfFfMW/DLy0LSbHxv/4lZJ+v//lvyhJsmasevEvc96imfnH4zE5/7yxe73DTe7j9AA==}
+    peerDependencies:
+      '@electric-sql/client': 1.0.4
 
   '@electric-sql/pglite-sync@0.3.6':
     resolution: {integrity: sha512-fZDfoLlfYBBBPwPWV+PSskzW8jQR3hpHxWomovcYxCnP0+dAz4i+N+ybwFeDbYW8VoflGQatC4g+sJPYImoFEA==}
@@ -4604,6 +4612,12 @@ snapshots:
       '@rollup/rollup-darwin-arm64': 4.42.0
 
   '@electric-sql/experimental@1.0.0(@electric-sql/client@1.0.0)':
+    dependencies:
+      '@electric-sql/client': 1.0.0
+    optionalDependencies:
+      '@rollup/rollup-darwin-arm64': 4.42.0
+
+  '@electric-sql/experimental@1.0.4(@electric-sql/client@1.0.0)':
     dependencies:
       '@electric-sql/client': 1.0.0
     optionalDependencies:

--- a/src/lib/client/db/index.svelte.ts
+++ b/src/lib/client/db/index.svelte.ts
@@ -133,6 +133,9 @@ export const initializeClientDbPromise = initializeClientDb();
 
 let currentStreams: SyncShapesToTablesResult | null = null;
 
+export const electricStreams = () => currentStreams?.streams ?? null;
+export const syncStreams = () => currentStreams;
+
 async function startShapesSync() {
   if (currentStreams) {
     console.log("Already syncing shapes");

--- a/src/lib/client/db/index.svelte.ts
+++ b/src/lib/client/db/index.svelte.ts
@@ -133,7 +133,6 @@ export const initializeClientDbPromise = initializeClientDb();
 
 let currentStreams: SyncShapesToTablesResult | null = null;
 
-export const electricStreams = () => currentStreams?.streams ?? null;
 export const syncStreams = () => currentStreams;
 
 async function startShapesSync() {

--- a/src/lib/components/chatInput/ChatMessageInput.svelte
+++ b/src/lib/components/chatInput/ChatMessageInput.svelte
@@ -11,6 +11,8 @@
   import KeyboardShortcuts from "../utils/KeyboardShortcuts.svelte";
   import ModelPickerPopover from "./ModelPickerPopover.svelte";
   import { afterNavigate, goto } from "$app/navigation";
+  import { electricStreams } from "$lib/client/db/index.svelte";
+  import { matchBy, matchStream } from "@electric-sql/experimental";
   import { getCurrentChatState } from "$lib/client/state/currentChatState.svelte";
   import { Toggle } from "../ui/toggle";
   import { Select, SelectContent, SelectItem, SelectTrigger } from "../ui/select";
@@ -108,7 +110,15 @@
           });
           value = "";
 
-          // Maybe we should wait for the local DB to have this chatId, but since for now we're doing SSR, it should be fine...
+          const chatStream = electricStreams()?.chat;
+          if (chatStream) {
+            try {
+              await matchStream(chatStream, ['insert'], matchBy('id', chatDetails.chatId));
+            } catch (err) {
+              console.error('Waiting for chat sync failed', err);
+            }
+          }
+
           await goto(`/chat/${chatDetails.chatId}`);
         } catch (e) {
           if (e instanceof ORPCError) {

--- a/src/lib/components/chatInput/ChatMessageInput.svelte
+++ b/src/lib/components/chatInput/ChatMessageInput.svelte
@@ -11,7 +11,7 @@
   import KeyboardShortcuts from "../utils/KeyboardShortcuts.svelte";
   import ModelPickerPopover from "./ModelPickerPopover.svelte";
   import { afterNavigate, goto } from "$app/navigation";
-  import { electricStreams } from "$lib/client/db/index.svelte";
+  import { syncStreams } from "$lib/client/db/index.svelte";
   import { matchBy, matchStream } from "@electric-sql/experimental";
   import { getCurrentChatState } from "$lib/client/state/currentChatState.svelte";
   import { Toggle } from "../ui/toggle";
@@ -110,12 +110,12 @@
           });
           value = "";
 
-          const chatStream = electricStreams()?.chat;
+          const chatStream = syncStreams()?.streams.chat;
           if (chatStream) {
             try {
-              await matchStream(chatStream, ['insert'], matchBy('id', chatDetails.chatId));
+              await matchStream(chatStream, ["insert"], matchBy("id", chatDetails.chatId), 5000);
             } catch (err) {
-              console.error('Waiting for chat sync failed', err);
+              console.error("Waiting for chat sync failed", err);
             }
           }
 

--- a/src/lib/server/orpc/routes/v1/chat.ts
+++ b/src/lib/server/orpc/routes/v1/chat.ts
@@ -27,7 +27,7 @@ export const v1ChatRouter = osBase.router({
     .input(
       z.object({
         model: z.enum(MODELS),
-        message: z.string().min(1).max(4096),
+        message: z.string().min(1).max(10000),
         webSearchEnabled: z.boolean().optional(),
         reasoningLevel: z.enum(REASONING_LEVELS).optional(),
       }),
@@ -193,7 +193,7 @@ export const v1ChatRouter = osBase.router({
         chatId: z.string().uuid(),
         model: z.enum(MODELS).optional(),
         parentMessageId: z.string().uuid().nullable(),
-        message: z.string().min(1).max(4096),
+        message: z.string().min(1).max(10000),
         webSearchEnabled: z.boolean().optional(),
         reasoningLevel: z.enum(REASONING_LEVELS).optional(),
       }),

--- a/src/routes/(settings)/settings/byok/+page.svelte
+++ b/src/routes/(settings)/settings/byok/+page.svelte
@@ -73,7 +73,7 @@
         {/await}
       {/if}
     </CardContent>
-    <CardFooter class="flex justify-end border-t px-6 py-4">
+    <CardFooter class="justify-end">
       {#if data.byok.openrouter === null}
         <Button href="/auth">Log In</Button>
       {:else}


### PR DESCRIPTION
## Summary
- expose Electric sync streams via `electricStreams`
- await chat insert on local DB before navigation

## Testing
- `pnpm lint` *(fails: 18 errors)*
- `pnpm format` *(fails: code style issues)*
- `pnpm typecheck` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68542268f134832fa566fb60b9d990fe