### PR TITLE
Enable OpenRouter user tracking

### DIFF
--- a/src/lib/server/ai/agents/main.ts
+++ b/src/lib/server/ai/agents/main.ts
@@ -100,6 +100,7 @@ export function createAgent(
     const stream = await createOpenAIClient(openRouterKey).chat.completions.create({
       model: actualModel,
       messages: state.messages,
+      user: state.userId,
       stream: true,
       reasoning_effort:
         parameters.thinking === undefined

--- a/src/lib/server/ai/agents/title.ts
+++ b/src/lib/server/ai/agents/title.ts
@@ -31,6 +31,7 @@ export async function generateChatTitle(
         content: firstMessage,
       },
     ],
+    user: context.userId,
     response_format: {
       type: "json_schema",
       json_schema: { name: "title", schema: z.toJSONSchema(schema), strict: true },


### PR DESCRIPTION
## Summary
- include user ID in title generation requests
- include user ID in regular OpenRouter requests

## Testing
- `pnpm format`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68585d23eda4832fae08c2a5c4d785bb