### PR TITLE
Implement message cancellation

### DIFF
--- a/src/lib/server/ai/utils/cancellation.ts
+++ b/src/lib/server/ai/utils/cancellation.ts
@@ -1,0 +1,18 @@
+import { sql } from "$lib/server/db";
+
+const PREFIX = "cancel_";
+
+export async function listenForCancellation(messageId: string, onCancel: () => void) {
+  const channel = PREFIX + messageId;
+  const { unlisten } = await sql.listen(channel, () => {
+    onCancel();
+  });
+
+  return async () => {
+    await unlisten();
+  };
+}
+
+export function notifyCancellation(messageId: string) {
+  return sql.notify(PREFIX + messageId);
+}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -8,8 +8,8 @@ import type { PgTransaction } from "drizzle-orm/pg-core";
 
 if (!env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
 
-const client = postgres(env.DATABASE_URL);
-export const db = drizzle(client, {
+export const sql = postgres(env.DATABASE_URL);
+export const db = drizzle(sql, {
   schema,
   casing: "snake_case",
 });


### PR DESCRIPTION
## Summary
- add cancellation utilities using Postgres listen/notify
- allow `createAgent` to receive abort signals
- cancel agent stream on notification and mark message cancelled
- support cancellation in message routes and expose new `cancelMessage` method
- export `sql` client from DB layer

## Testing
- `pnpm lint`
- `pnpm format:fix`

------
https://chatgpt.com/codex/tasks/task_e_6859361fc39c832fa0baab74dc07b690