### PR TITLE
Fix send button when not in chat

### DIFF
--- a/src/lib/components/chatInput/ChatMessageInput.svelte
+++ b/src/lib/components/chatInput/ChatMessageInput.svelte
@@ -189,7 +189,7 @@
     const currentChatState = getCurrentChatState();
     return currentChatState?.lastMessageStatus
       ? isFinishedMessageStatus(currentChatState.lastMessageStatus)
-      : false;
+      : true;
   });
 </script>
 


### PR DESCRIPTION
## Summary
- treat undefined `lastMessageStatus` as finished so the send button shows when not in a chat

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: svelte-check found an error in src/routes/+layout.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685c71123e0c832faed237a23df388bd