### PR TITLE
Implement chat sharing backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "is-promise": "^4.0.0",
     "js-cookie": "^3.0.5",
     "katex": "^0.16.22",
+    "nanoid": "^5.1.5",
     "postgres": "^3.4.7",
     "posthog-js": "^1.255.0",
     "rehype-katex": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       katex:
         specifier: ^0.16.22
         version: 0.16.22
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
@@ -3500,6 +3503,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -7905,6 +7913,8 @@ snapshots:
   mustache@4.2.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.5: {}
 
   natural-compare@1.4.0: {}
 

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -21,3 +21,9 @@ export const isFinishedMessageStatus = (status: MessageStatus) =>
 export const MESSAGE_SEGMENT_KINDS = ["reasoning", "text", "tool_call", "tool_result"] as const;
 
 export type MessageSegmentKind = (typeof MESSAGE_SEGMENT_KINDS)[number];
+
+export const SHARE_TYPES = ["message", "thread", "chat"] as const;
+export type ShareType = (typeof SHARE_TYPES)[number];
+
+export const SHARE_PRIVACY_OPTIONS = ["private", "emails", "public"] as const;
+export type SharePrivacy = (typeof SHARE_PRIVACY_OPTIONS)[number];

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from "./users";
 export * from "./chats";
 export * from "./byok";
+export * from "./shares";

--- a/src/lib/server/db/schema/shares.ts
+++ b/src/lib/server/db/schema/shares.ts
@@ -1,0 +1,61 @@
+import { pgTable, uuid, varchar, timestamp, jsonb } from "drizzle-orm/pg-core";
+import { userTable } from "./users";
+import { chatTable, threadTable, messageTable } from "./chats";
+import { SHARE_PRIVACY_OPTIONS } from "$lib/common";
+
+export const messageShareTable = pgTable("message_share", {
+  id: varchar({ length: 21 }).primaryKey(),
+  userId: uuid()
+    .notNull()
+    .references(() => userTable.id, { onDelete: "cascade" }),
+  chatId: uuid()
+    .notNull()
+    .references(() => chatTable.id, { onDelete: "cascade" }),
+  threadId: uuid()
+    .notNull()
+    .references(() => threadTable.id, { onDelete: "cascade" }),
+  messageId: uuid()
+    .notNull()
+    .references(() => messageTable.id, { onDelete: "cascade" }),
+  privacy: varchar({ length: 20, enum: SHARE_PRIVACY_OPTIONS }).notNull().default("private"),
+  allowedEmails: jsonb("allowed_emails").notNull().default([]),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+});
+
+export const threadShareTable = pgTable("thread_share", {
+  id: varchar({ length: 21 }).primaryKey(),
+  userId: uuid()
+    .notNull()
+    .references(() => userTable.id, { onDelete: "cascade" }),
+  chatId: uuid()
+    .notNull()
+    .references(() => chatTable.id, { onDelete: "cascade" }),
+  threadId: uuid()
+    .notNull()
+    .references(() => threadTable.id, { onDelete: "cascade" }),
+  lastMessageId: uuid()
+    .notNull()
+    .references(() => messageTable.id, { onDelete: "cascade" }),
+  privacy: varchar({ length: 20, enum: SHARE_PRIVACY_OPTIONS }).notNull().default("private"),
+  allowedEmails: jsonb("allowed_emails").notNull().default([]),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+});
+
+export const chatShareTable = pgTable("chat_share", {
+  chatId: uuid()
+    .primaryKey()
+    .references(() => chatTable.id, { onDelete: "cascade" }),
+  userId: uuid()
+    .notNull()
+    .references(() => userTable.id, { onDelete: "cascade" }),
+  privacy: varchar({ length: 20, enum: SHARE_PRIVACY_OPTIONS }).notNull().default("private"),
+  allowedEmails: jsonb("allowed_emails").notNull().default([]),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+});
+
+export type MessageShare = typeof messageShareTable.$inferSelect;
+export type ThreadShare = typeof threadShareTable.$inferSelect;
+export type ChatShare = typeof chatShareTable.$inferSelect;

--- a/src/lib/server/orpc/routes/v1/index.ts
+++ b/src/lib/server/orpc/routes/v1/index.ts
@@ -1,9 +1,11 @@
 import { v1ChatRouter } from "./chat";
 import { v1ByokRouter } from "./byok";
 import { v1AuthRouter } from "./auth";
+import { v1ShareRouter } from "./share";
 
 export const v1Router = {
   chat: v1ChatRouter,
   byok: v1ByokRouter,
   auth: v1AuthRouter,
+  share: v1ShareRouter,
 };

--- a/src/lib/server/orpc/routes/v1/share.ts
+++ b/src/lib/server/orpc/routes/v1/share.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { osBase } from "../../context";
+import { authenticatedMiddleware } from "../../middlewares";
+import {
+  createMessageShare,
+  createThreadShare,
+  createChatShare,
+} from "$lib/server/services/shares";
+import { SHARE_PRIVACY_OPTIONS } from "$lib/common";
+
+const messageInput = z.object({
+  messageId: z.string().uuid(),
+  privacy: z.enum(SHARE_PRIVACY_OPTIONS).default("public"),
+  emails: z.array(z.string().email()).optional(),
+});
+
+const threadInput = z.object({
+  threadId: z.string().uuid(),
+  lastMessageId: z.string().uuid(),
+  privacy: z.enum(SHARE_PRIVACY_OPTIONS).default("public"),
+  emails: z.array(z.string().email()).optional(),
+});
+
+const chatInput = z.object({
+  chatId: z.string().uuid(),
+  privacy: z.enum(SHARE_PRIVACY_OPTIONS).default("public"),
+  emails: z.array(z.string().email()).optional(),
+});
+
+export const v1ShareRouter = osBase.router({
+  message: osBase.router({
+    create: osBase
+      .use(authenticatedMiddleware)
+      .input(messageInput)
+      .handler(async ({ context, input }) =>
+        createMessageShare(
+          context.userCtx.user.id,
+          input.messageId,
+          input.privacy,
+          input.emails ?? [],
+        ),
+      ),
+  }),
+  thread: osBase.router({
+    create: osBase
+      .use(authenticatedMiddleware)
+      .input(threadInput)
+      .handler(async ({ context, input }) =>
+        createThreadShare(
+          context.userCtx.user.id,
+          input.threadId,
+          input.lastMessageId,
+          input.privacy,
+          input.emails ?? [],
+        ),
+      ),
+  }),
+  chat: osBase.router({
+    create: osBase
+      .use(authenticatedMiddleware)
+      .input(chatInput)
+      .handler(async ({ context, input }) =>
+        createChatShare(context.userCtx.user.id, input.chatId, input.privacy, input.emails ?? []),
+      ),
+  }),
+});

--- a/src/lib/server/services/shares.ts
+++ b/src/lib/server/services/shares.ts
@@ -1,0 +1,114 @@
+import { eq } from "drizzle-orm";
+import { db } from "$lib/server/db";
+import {
+  chatTable,
+  messageTable,
+  threadTable,
+  messageShareTable,
+  threadShareTable,
+  chatShareTable,
+} from "$lib/server/db/schema";
+import { nanoid } from "nanoid";
+import type { SharePrivacy } from "$lib/common";
+
+export async function createMessageShare(
+  userId: string,
+  messageId: string,
+  privacy: SharePrivacy,
+  emails: string[] = [],
+) {
+  const [msg] = await db
+    .select({
+      chatId: messageTable.chatId,
+      threadId: messageTable.threadId,
+      userId: messageTable.userId,
+    })
+    .from(messageTable)
+    .where(eq(messageTable.id, messageId))
+    .limit(1);
+
+  if (!msg || msg.userId !== userId) {
+    throw new Error("Message not found");
+  }
+
+  const id = nanoid();
+  await db.insert(messageShareTable).values({
+    id,
+    userId,
+    chatId: msg.chatId,
+    threadId: msg.threadId,
+    messageId,
+    privacy,
+    allowedEmails: emails,
+  });
+  return { id };
+}
+
+export async function createThreadShare(
+  userId: string,
+  threadId: string,
+  lastMessageId: string,
+  privacy: SharePrivacy,
+  emails: string[] = [],
+) {
+  const [thread] = await db
+    .select({ chatId: threadTable.chatId, userId: threadTable.userId })
+    .from(threadTable)
+    .where(eq(threadTable.id, threadId))
+    .limit(1);
+
+  if (!thread || thread.userId !== userId) {
+    throw new Error("Thread not found");
+  }
+
+  const id = nanoid();
+  await db.insert(threadShareTable).values({
+    id,
+    userId,
+    chatId: thread.chatId,
+    threadId,
+    lastMessageId,
+    privacy,
+    allowedEmails: emails,
+  });
+  return { id };
+}
+
+export async function createChatShare(
+  userId: string,
+  chatId: string,
+  privacy: SharePrivacy,
+  emails: string[] = [],
+) {
+  const [chat] = await db
+    .select({ userId: chatTable.userId })
+    .from(chatTable)
+    .where(eq(chatTable.id, chatId))
+    .limit(1);
+
+  if (!chat || chat.userId !== userId) {
+    throw new Error("Chat not found");
+  }
+
+  const [existing] = await db
+    .select()
+    .from(chatShareTable)
+    .where(eq(chatShareTable.chatId, chatId))
+    .limit(1);
+
+  if (existing) {
+    await db
+      .update(chatShareTable)
+      .set({ privacy, allowedEmails: emails, updatedAt: new Date() })
+      .where(eq(chatShareTable.chatId, chatId));
+  } else {
+    await db.insert(chatShareTable).values({
+      chatId,
+      userId,
+      privacy,
+      allowedEmails: emails,
+    });
+  }
+
+  return { chatId };
+}

--- a/src/routes/(chat)/sc/[shareId]/+page.server.ts
+++ b/src/routes/(chat)/sc/[shareId]/+page.server.ts
@@ -1,0 +1,55 @@
+import type { PageServerLoad } from "./$types";
+import { db } from "$lib/server/db";
+import { chatShareTable, messageTable } from "$lib/server/db/schema";
+import { eq, desc } from "drizzle-orm";
+import { fetchThreadMessagesRecursive } from "$lib/server/services/messages";
+import { error } from "@sveltejs/kit";
+
+function checkPrivacy(
+  share: { privacy: string; allowedEmails: unknown },
+  userEmail: string | null,
+) {
+  if (share.privacy === "private") return false;
+  if (share.privacy === "emails") {
+    const list = (share.allowedEmails as string[]) || [];
+    return userEmail !== null && list.includes(userEmail);
+  }
+  return true;
+}
+
+export const load: PageServerLoad = async ({ params, locals, setHeaders }) => {
+  const { shareId } = params;
+
+  const [chatShare] = await db
+    .select()
+    .from(chatShareTable)
+    .where(eq(chatShareTable.chatId, shareId));
+
+  if (!chatShare) {
+    throw error(404, "Not found");
+  }
+
+  if (!checkPrivacy(chatShare, locals.user?.email ?? null)) {
+    throw error(401, "Unauthorized");
+  }
+  if (chatShare.privacy === "public") {
+    setHeaders({ "X-Robots-Tag": "noindex" });
+  }
+
+  const [lastMessage] = await db
+    .select({ messageId: messageTable.id, threadId: messageTable.threadId })
+    .from(messageTable)
+    .where(eq(messageTable.chatId, chatShare.chatId))
+    .orderBy(desc(messageTable.createdAt))
+    .limit(1);
+
+  if (!lastMessage) {
+    return { type: "chat", messages: [], chatId: chatShare.chatId };
+  }
+
+  const messages = await fetchThreadMessagesRecursive(db, lastMessage.threadId, {
+    lastMessageId: lastMessage.messageId,
+    maxDepth: 15,
+  });
+  return { type: "chat", messages, chatId: chatShare.chatId };
+};

--- a/src/routes/(chat)/sc/[shareId]/+page.svelte
+++ b/src/routes/(chat)/sc/[shareId]/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import RecursiveMessageRendering from "$lib/components/chatMessages/RecursiveMessageRendering.svelte";
+  import type { PageProps } from "./$types";
+  import { cn } from "$lib/utils";
+  import { isSidebarCollapsed } from "../../+layout.svelte";
+
+  const { data }: PageProps = $props();
+</script>
+
+<div
+  class={cn(
+    "mx-auto flex w-full max-w-screen min-w-0 flex-col gap-2 overflow-x-hidden px-4 pt-16 pb-36",
+    isSidebarCollapsed()
+      ? "md:max-w-screen-md"
+      : "md:max-w-[min(var(--breakpoint-md),calc(100vw-var(--spacing)*80)))]",
+  )}
+>
+  <RecursiveMessageRendering messages={data.messages} chatId={data.chatId} chat={null} />
+</div>

--- a/src/routes/(chat)/sm/[shareId]/+page.server.ts
+++ b/src/routes/(chat)/sm/[shareId]/+page.server.ts
@@ -1,0 +1,43 @@
+import type { PageServerLoad } from "./$types";
+import { db } from "$lib/server/db";
+import { messageShareTable } from "$lib/server/db/schema";
+import { eq } from "drizzle-orm";
+import { fetchThreadMessagesRecursive } from "$lib/server/services/messages";
+import { error } from "@sveltejs/kit";
+
+function checkPrivacy(
+  share: { privacy: string; allowedEmails: unknown },
+  userEmail: string | null,
+) {
+  if (share.privacy === "private") return false;
+  if (share.privacy === "emails") {
+    const list = (share.allowedEmails as string[]) || [];
+    return userEmail !== null && list.includes(userEmail);
+  }
+  return true;
+}
+
+export const load: PageServerLoad = async ({ params, locals, setHeaders }) => {
+  const { shareId } = params;
+
+  const [msgShare] = await db
+    .select()
+    .from(messageShareTable)
+    .where(eq(messageShareTable.id, shareId));
+
+  if (!msgShare) {
+    throw error(404, "Not found");
+  }
+
+  if (!checkPrivacy(msgShare, locals.user?.email ?? null)) {
+    throw error(401, "Unauthorized");
+  }
+  if (msgShare.privacy === "public") {
+    setHeaders({ "X-Robots-Tag": "noindex" });
+  }
+  const messages = await fetchThreadMessagesRecursive(db, msgShare.threadId, {
+    lastMessageId: msgShare.messageId,
+    maxDepth: 15,
+  });
+  return { type: "message", messages, chatId: msgShare.chatId };
+};

--- a/src/routes/(chat)/sm/[shareId]/+page.svelte
+++ b/src/routes/(chat)/sm/[shareId]/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import RecursiveMessageRendering from "$lib/components/chatMessages/RecursiveMessageRendering.svelte";
+  import type { PageProps } from "./$types";
+  import { cn } from "$lib/utils";
+  import { isSidebarCollapsed } from "../../+layout.svelte";
+
+  const { data }: PageProps = $props();
+</script>
+
+<div
+  class={cn(
+    "mx-auto flex w-full max-w-screen min-w-0 flex-col gap-2 overflow-x-hidden px-4 pt-16 pb-36",
+    isSidebarCollapsed()
+      ? "md:max-w-screen-md"
+      : "md:max-w-[min(var(--breakpoint-md),calc(100vw-var(--spacing)*80)))]",
+  )}
+>
+  <RecursiveMessageRendering messages={data.messages} chatId={data.chatId} chat={null} />
+</div>

--- a/src/routes/(chat)/st/[shareId]/+page.server.ts
+++ b/src/routes/(chat)/st/[shareId]/+page.server.ts
@@ -1,0 +1,43 @@
+import type { PageServerLoad } from "./$types";
+import { db } from "$lib/server/db";
+import { threadShareTable } from "$lib/server/db/schema";
+import { eq } from "drizzle-orm";
+import { fetchThreadMessagesRecursive } from "$lib/server/services/messages";
+import { error } from "@sveltejs/kit";
+
+function checkPrivacy(
+  share: { privacy: string; allowedEmails: unknown },
+  userEmail: string | null,
+) {
+  if (share.privacy === "private") return false;
+  if (share.privacy === "emails") {
+    const list = (share.allowedEmails as string[]) || [];
+    return userEmail !== null && list.includes(userEmail);
+  }
+  return true;
+}
+
+export const load: PageServerLoad = async ({ params, locals, setHeaders }) => {
+  const { shareId } = params;
+
+  const [threadShare] = await db
+    .select()
+    .from(threadShareTable)
+    .where(eq(threadShareTable.id, shareId));
+
+  if (!threadShare) {
+    throw error(404, "Not found");
+  }
+
+  if (!checkPrivacy(threadShare, locals.user?.email ?? null)) {
+    throw error(401, "Unauthorized");
+  }
+  if (threadShare.privacy === "public") {
+    setHeaders({ "X-Robots-Tag": "noindex" });
+  }
+  const messages = await fetchThreadMessagesRecursive(db, threadShare.threadId, {
+    lastMessageId: threadShare.lastMessageId,
+    maxDepth: 15,
+  });
+  return { type: "thread", messages, chatId: threadShare.chatId };
+};

--- a/src/routes/(chat)/st/[shareId]/+page.svelte
+++ b/src/routes/(chat)/st/[shareId]/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import RecursiveMessageRendering from "$lib/components/chatMessages/RecursiveMessageRendering.svelte";
+  import type { PageProps } from "./$types";
+  import { cn } from "$lib/utils";
+  import { isSidebarCollapsed } from "../../+layout.svelte";
+
+  const { data }: PageProps = $props();
+</script>
+
+<div
+  class={cn(
+    "mx-auto flex w-full max-w-screen min-w-0 flex-col gap-2 overflow-x-hidden px-4 pt-16 pb-36",
+    isSidebarCollapsed()
+      ? "md:max-w-screen-md"
+      : "md:max-w-[min(var(--breakpoint-md),calc(100vw-var(--spacing)*80)))]",
+  )}
+>
+  <RecursiveMessageRendering messages={data.messages} chatId={data.chatId} chat={null} />
+</div>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,7 +7,7 @@ import { ORPCError } from "@orpc/client";
 import { env } from "$env/dynamic/public";
 
 export const load: LayoutLoad = async ({ data }) => {
-  if (browser) {
+  if (browser && env.PUBLIC_POSTHOG_API_KEY && env.PUBLIC_POSTHOG_HOST) {
     posthog.init(env.PUBLIC_POSTHOG_API_KEY, {
       api_host: env.PUBLIC_POSTHOG_HOST,
       person_profiles: "identified_only",


### PR DESCRIPTION
## Summary
- add dedicated share routes for threads, messages and chats
- add server pages for each share type and reuse chat layout
- split ORPC share router into message, thread and chat sections
- ensure PostHog is only initialized when env vars are present

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6862e01bf780832f8e784705f9e61c59