### PR TITLE
Add docs link in sidebar dropdown

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -23,6 +23,7 @@
     Loader2,
     XIcon,
     KeyboardIcon,
+    BookOpenIcon,
   } from "@lucide/svelte";
   import { goto } from "$app/navigation";
   import { orpc } from "$lib/client/orpc";
@@ -212,6 +213,10 @@
             <DropdownMenuItem onclick={() => goto("/settings")}>
               <SettingsIcon class="mr-2 size-4" />
               <span>Settings</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onclick={() => window.open("https://docs.boreal.chat", "_blank")}>
+              <BookOpenIcon class="mr-2 size-4" />
+              <span>Docs</span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onclick={onLogout} variant="destructive" disabled={logoutLoading}>


### PR DESCRIPTION
## Summary
- include `BookOpenIcon`
- link to the documentation site from the sidebar dropdown

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string')*

------
https://chatgpt.com/codex/tasks/task_e_6862fd3cc584832f9a92828946fdc79a