### PR TITLE
Reduce streaming buffer latency

### DIFF
--- a/src/lib/server/ai/utils/BufferedTokenInsert.ts
+++ b/src/lib/server/ai/utils/BufferedTokenInsert.ts
@@ -26,8 +26,9 @@ class BufferedTokenInsert {
   private lastInsert: number = 0;
   private buffer: string = "";
   private flushTimer: NodeJS.Timeout | null = null;
-  private readonly FLUSH_TIMEOUT = 400; // 400ms
-  private readonly BUFFER_THRESHOLD = 100; // characters threshold
+  // Flush sooner so streaming tokens reach the DB more quickly
+  private readonly FLUSH_TIMEOUT = 100; // 100ms
+  private readonly BUFFER_THRESHOLD = 20; // characters threshold
   private readonly BATCH_FLUSH_DELAY = 10; // 10ms to collect batches
   private isDestroyed = false;
 


### PR DESCRIPTION
## Summary
- lower the buffer threshold and flush timeout so tokens sync faster to the DB

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_6862fa9b8fc0832f882f3fd722abaade