### PR TITLE
Fix chat layout for phones

### DIFF
--- a/src/routes/(chat)/+layout.svelte
+++ b/src/routes/(chat)/+layout.svelte
@@ -186,7 +186,7 @@
   </Sheet>
 </div>
 
-<div class="flex h-[100dvh] w-full flex-row">
+<div class="flex min-h-screen w-full flex-row md:h-[100dvh]">
   <!-- Desktop Sidebar -->
   <div
     class={cn(
@@ -198,12 +198,19 @@
   </div>
 
   <div class="relative flex-1 flex-grow">
-    <main class="h-full overflow-y-auto" bind:this={chatContainer} onscroll={handleScroll}>
+    <main
+      class="min-h-screen md:h-full md:overflow-y-auto"
+      bind:this={chatContainer}
+      onscroll={handleScroll}
+    >
       {@render children()}
     </main>
 
     <!-- Chat message input -->
-    <div class="pointer-events-none absolute right-0 bottom-0 left-0">
+    <div
+      class="pointer-events-none absolute right-0 bottom-0 left-0"
+      style="padding-bottom: env(safe-area-inset-bottom)"
+    >
       {#if !autoscroll}
         <button
           onclick={resumeAutoScroll}

--- a/src/routes/(chat)/chat/[chatId=uuid]/+page.svelte
+++ b/src/routes/(chat)/chat/[chatId=uuid]/+page.svelte
@@ -19,11 +19,12 @@
 
 <div
   class={cn(
-    "mx-auto flex w-full max-w-screen min-w-0 flex-col gap-2 overflow-x-hidden px-4 pt-16 pb-36",
+    "mx-auto flex w-full max-w-screen min-w-0 flex-col gap-2 overflow-x-hidden px-4 pt-16",
     isSidebarCollapsed()
       ? "md:max-w-screen-md"
       : "md:max-w-[min(var(--breakpoint-md),calc(100vw-var(--spacing)*80)))]",
   )}
+  style="padding-bottom: calc(9rem + env(safe-area-inset-bottom))"
 >
   {#if $messages.loading || !$messages.data}
     <ChatSkeleton />


### PR DESCRIPTION
## Summary
- allow page scroll on mobile instead of inner div scroll
- respect safe area inset for the chat input container
- add safe area padding for message list

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: auth token)*
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_6862f49d1dac832f8cb597639468d227