### PR TITLE
Preserve user message formatting

### DIFF
--- a/src/lib/components/chatMessages/ChatMessage.svelte
+++ b/src/lib/components/chatMessages/ChatMessage.svelte
@@ -243,7 +243,11 @@
     >
       {#each cleanedSegments as segment (segment.ordinal)}
         {#if segment.kind === "text"}
-          <Markdown content={segment.content ?? ""} />
+          {#if isUser}
+            <div class="whitespace-pre-wrap">{segment.content ?? ""}</div>
+          {:else}
+            <Markdown content={segment.content ?? ""} />
+          {/if}
         {:else if segment.kind === "reasoning"}
           <ReasoningSegment reasoning={segment.content ?? ""} isReasoning={segment.streamed} />
         {:else if segment.kind === "tool_call"}


### PR DESCRIPTION
Disable markdown rendering for user messages in ChatMessage to preserve original input formatting.

Previously, all messages were markdown-rendered, causing user-typed markdown to be formatted unexpectedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User messages in the chat now display text with preserved whitespace and line breaks, improving readability and matching input formatting.
* **Style**
  * Updated the appearance of user messages to better reflect their original formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->