### PR TITLE
Add redis to deployment

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -48,5 +48,31 @@ services:
       postgres:
         condition: service_healthy
 
+  redis:
+    image: redis:latest
+    ports:
+      - 6379
+    volumes:
+      - redis-data:/data
+
+  minio:
+    image: minio/minio:latest
+    ports:
+      - 9000
+      - 9001
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio-data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
 volumes:
   postgres-data:
+  redis-data:
+  minio-data:


### PR DESCRIPTION
Add Redis and MinIO services to `docker-compose.deploy.yaml` to complete the deployment configuration.

---

[Open in Web](https://cursor.com/agents?id=bc-04592fac-5f14-4661-9218-69c8e700117d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-04592fac-5f14-4661-9218-69c8e700117d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)